### PR TITLE
Fix 'Extra argument /bin/bash.'

### DIFF
--- a/gitolite/Dockerfile
+++ b/gitolite/Dockerfile
@@ -33,6 +33,6 @@ RUN sed -i '/session    required     pam_loginuid.so/d' /etc/pam.d/sshd
 
 ADD ./init.sh /init
 RUN chmod +x /init
-ENTRYPOINT ["/init", "/usr/sbin/sshd", "-D"]
+CMD ["/init", "/usr/sbin/sshd", "-D"]
 
 EXPOSE 22


### PR DESCRIPTION
Recommendation from https://github.com/bjonnh/docker-skype-pulseaudio/commit/a7784d617985ee11e15b36e3d890e1cab622267d
