### PR TITLE
Addind volume to repositories directory

### DIFF
--- a/gitolite/Dockerfile
+++ b/gitolite/Dockerfile
@@ -32,6 +32,10 @@ RUN chown -R git:git /home/git
 RUN sed -i '/session    required     pam_loginuid.so/d' /etc/pam.d/sshd
 
 ADD ./init.sh /init
+
+# Addind volume to repositories directory
+VOLUME /home/git/repositories
+
 RUN chmod +x /init
 ENTRYPOINT ["/init", "/usr/sbin/sshd", "-D"]
 


### PR DESCRIPTION
Adding volume to repositories directory is usefull to using image as data container as well.

So you can start a container by running /bin/true and using this container with the --volumes-from option as data container.

ref: http://container42.com/2014/11/18/data-only-container-madness/